### PR TITLE
fix: container cmd override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "aws_ecs_task_definition" "task" {
     name        = var.name
     image       = var.image
     essential   = true
-    command     = split(" ", var.command)
+    command     = var.command != "" ? split(" ", var.command) : null
     environment = local.environ
     secrets     = local.secrets
     logConfiguration = {


### PR DESCRIPTION
Avoid setting container command override to an array containing an empty
string.